### PR TITLE
Fix requirements.txt for Python 3.11 on Windows, README, f-strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,8 +376,8 @@ Make sure the following are installed on your machine before cloning:
 ### Clone & Install
 
 ```bash
-git clone https://github.com/Hyacinthe-primus/file-converter-pro.git
-cd file-converter-pro
+git clone https://github.com/Hyacinthe-primus/File_Converter_Pro.git
+cd File_Converter_Pro
 pip install -r requirements.txt
 ```
 

--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -462,7 +462,8 @@ class PreviewDialog(QDialog):
             else:
                 self.preview_unsupported()
         except Exception as e:
-            self._show_error(f"{self.translate_text('Erreur lors du chargement de l\'aperçu:')}\n{e}")
+            translated_msg = self.translate_text('Erreur lors du chargement de l\'aperçu:')
+            self._show_error(f"{translated_msg}\n{e}")
 
     def preview_pdf(self):
         try:

--- a/dialogs/terms_dialog.py
+++ b/dialogs/terms_dialog.py
@@ -208,7 +208,8 @@ class TermsAndPrivacyDialog(QDialog):
         terms_layout.setContentsMargins(15, 12, 15, 15)
 
         title_color = "#ffffff" if self.dark_mode else "#212529"
-        terms_title = QLabel(f"<h2 style='color: {title_color}; margin: 0 0 8px 0;'>{self.translate_text('Conditions d\'utilisation')}</h2>")
+        translated_msg = self.translate_text('Conditions d\'utilisation')
+        terms_title = QLabel(f"<h2 style='color: {title_color}; margin: 0 0 8px 0;'>{translated_msg}</h2>")
         terms_title.setStyleSheet(f"background-color: transparent; color: {title_color};")
         terms_layout.addWidget(terms_title)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ openpyxl==3.1.5
 
 #Images
 Pillow==12.0.0
-pillow-heifPillow==1.3.0
+pillow-heif==1.3.0
 
 # E-books
 ebooklib==0.20


### PR DESCRIPTION
Hi!

I have few changes to the code. This morning I changed something in order to install the packages in the virtual environment and to run the script.

Concerning requirements.txt, I saw that these packages work with Python 3.11 (I'm using Python 3.11.9), but there could be incompatibilities with Python 3.13. I fixed a typo in the requirements.txt (pillow-heif).

Concerning README.md, I changed the instructions inside the box to do correctly git clone and to navigate inside the folder.

About some other files, I fixed them since there were problems with f-strings and the use of apostrophe.

I tried the conversion from pdf to word and your tool works well. I appreciate this repo.

I hope my contribution was helpful.

Bye!

Ivan

