### PR TITLE
Add docstring to FadingMainWindow.__init__ method

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -30,6 +30,11 @@ class FileConverterApp(AppUIMixin, QMainWindow):
 class FadingMainWindow(FileConverterApp):
     """Version of FileConverterApp with fade-in support"""
     def __init__(self, config_manager):
+        """Initialize the fading window with fade-in animation support.
+
+        Args:
+            config_manager: The application configuration manager instance.
+        """
         super().__init__(config_manager)
         self.setWindowOpacity(0.0)
         QTimer.singleShot(0, self.set_application_icon)


### PR DESCRIPTION
This pull request adds a missing docstring to the public `__init__` method of the `FadingMainWindow` class in `app/__init__.py`.

### Problem
The `__init__` method of the `FadingMainWindow` class lacked a docstring. While the class and other methods had clear documentation, the constructor was undocumented, which could hinder code readability, maintenance, and the use of automated documentation tools.

### Changes
*   Added a concise and informative docstring to the `FadingMainWindow.__init__` method. The docstring follows the existing style (Google-style) used in the repository and describes the method's purpose and its single parameter.
*   The change is minimal and non-breaking. It does not alter the method's signature, behavior, or any public API.

### Verification
1.  **Code Review:** Please review the added docstring to ensure it accurately describes the method's intent and parameters.
2.  **Static Analysis:** Run the project's linter or type checker (e.g., `mypy`, `flake8`) to confirm no new warnings are introduced.
3.  **Manual Testing:** Launch the application to verify the fade-in animation on the main window still works as expected, confirming no functional regression.